### PR TITLE
[WIP][TASK] Remove redundant child nodes, use extended ContentCollection

### DIFF
--- a/Configuration/NodeTypes.Callouts.yaml
+++ b/Configuration/NodeTypes.Callouts.yaml
@@ -9,6 +9,7 @@
   superTypes:
     - 'TYPO3.Neos:Content'
     - 'M12.Foundation:AbstractDevCustomTag'
+    - 'TYPO3.Neos:ContentCollection'
   ui:
     label: 'Reveal Modal'
     icon: 'icon-fullscreen'
@@ -18,12 +19,6 @@
         options:
           label: 'Reveal Modal options'
           position: 9
-  constraints:
-    nodeTypes:
-      '*': FALSE # All content must go into child ContentCollection
-  childNodes:
-    content:
-      type: 'TYPO3.Neos:ContentCollection'
   properties:
     classRevealSize:
       type: string
@@ -61,6 +56,7 @@
   superTypes:
     - 'TYPO3.Neos:Content'
     - 'M12.Foundation:AbstractDevCustomTag'
+    - 'TYPO3.Neos:ContentCollection'
   ui:
     label: 'Alert'
     icon: 'icon-warning-sign'
@@ -70,12 +66,6 @@
         options:
           label: 'Alert box options'
           position: 9
-  constraints:
-    nodeTypes:
-      '*': FALSE # All content must go into child ContentCollection
-  childNodes:
-    content:
-      type: 'TYPO3.Neos:ContentCollection'
   properties:
     classAppearance:
       type: string
@@ -103,6 +93,7 @@
     - 'TYPO3.Neos:Content'
     - 'M12.Foundation:AbstractDevCustomTag'
     - 'M12.Foundation:AbstractNavSailingType'
+    - 'TYPO3.Neos:ContentCollection'
   ui:
     label: 'Panel'
     icon: 'icon-check-empty'
@@ -112,12 +103,6 @@
         options:
           label: 'Panel options'
           position: 9
-  constraints:
-    nodeTypes:
-      '*': FALSE # All content must go into child ContentCollection
-  childNodes:
-    content:
-      type: 'TYPO3.Neos:ContentCollection'
   properties:
     classCallout:
       type: boolean

--- a/Configuration/NodeTypes.Content.yaml
+++ b/Configuration/NodeTypes.Content.yaml
@@ -97,14 +97,12 @@
   superTypes:
     - 'TYPO3.Neos:Content'
     - 'M12.Foundation:DropdownAbstract'
+    - 'TYPO3.Neos:ContentCollection'
   ui:
     label: 'Dropdown: Content'
     icon: 'icon-collapse'
     group: 'interactive'
     inlineEditable: TRUE
-  childNodes:
-    content:
-      type: 'TYPO3.Neos:ContentCollection'
   properties:
     dropdownPadding:
       type: boolean
@@ -166,16 +164,11 @@
   superTypes:
     - 'TYPO3.Neos:Content'
     - 'M12.Foundation:AccordionAbstract'
+    - 'TYPO3.Neos:ContentCollection'
   ui:
     label: 'Accordion Item'
     icon: 'icon-reorder'
     group: 'structure'
-  constraints:
-    nodeTypes:
-      '*': FALSE # No children items allowed apart of child ContentCollection
-  childNodes:
-    content:
-      type: 'TYPO3.Neos:ContentCollection'
   properties:
     accordionItemLabel:
       type: string
@@ -233,6 +226,7 @@
 'M12.Foundation:TabItem':
   superTypes:
     - 'TYPO3.Neos:Content'
+    - 'TYPO3.Neos:ContentCollection'
   ui:
     label: 'Tab Item'
     icon: 'icon-angle-right'
@@ -241,12 +235,6 @@
         tabSettings:
           label: 'Tab item options'
           position: 9
-  constraints:
-    nodeTypes:
-      '*': FALSE # All content must go to child ContentCollection
-  childNodes:
-    content:
-      type: 'TYPO3.Neos:ContentCollection'
   properties:
     title:
       type: string

--- a/Configuration/NodeTypes.Forms.yaml
+++ b/Configuration/NodeTypes.Forms.yaml
@@ -8,6 +8,7 @@
 'M12.Foundation:Form':
   superTypes:
     - 'TYPO3.Neos:Content'
+    - 'TYPO3.Neos:ContentCollection'
     - 'M12.Foundation:AbstractNavSailingType'
   ui:
     label: 'Form container'
@@ -19,12 +20,6 @@
         formSettings:
           label: 'Form settings'
           position: 5
-  constraints:
-    nodeTypes:
-      '*': FALSE # All content must go into child ContentCollection
-  childNodes:
-    content:
-      type: 'TYPO3.Neos:ContentCollection'
   properties:
     actionUri:
       type: string
@@ -64,9 +59,6 @@
         dev:
           label: 'Advanced form element settings'
           position: 9
-  constraints:
-    nodeTypes:
-      '*': FALSE # All content must go into child ContentCollection
   properties:
     inputName:
       type: string
@@ -136,9 +128,6 @@
         formLabelSettings:
           label: 'Form label settings'
           position: 6
-  constraints:
-    nodeTypes:
-      '*': FALSE # All content must go into child ContentCollection
   properties:
     inputLabel:
       type: string
@@ -242,6 +231,7 @@
 'M12.Foundation:FormFieldset':
   superTypes:
     - 'TYPO3.Neos:Content'
+    - 'TYPO3.Neos:ContentCollection'
   ui:
     label: 'Form fieldset'
     icon: 'icon-check-empty'
@@ -251,12 +241,6 @@
         formInputSettings:
           label: 'Form input settings'
           position: 9
-  constraints:
-    nodeTypes:
-      '*': FALSE # All content must go into child ContentCollection
-  childNodes:
-    content:
-      type: 'TYPO3.Neos:ContentCollection'
   properties:
     legendTxt:
       type: string

--- a/Configuration/NodeTypes.Media.yaml
+++ b/Configuration/NodeTypes.Media.yaml
@@ -6,6 +6,7 @@
 'M12.Foundation:Orbit':
   superTypes:
     - 'TYPO3.Neos:Content'
+    - 'TYPO3.Neos:ContentCollection'
     - 'M12.Foundation:AbstractNodeTitle'
   ui:
     label: 'Orbit'
@@ -16,9 +17,6 @@
         orbitSettings:
           label: 'Orbit settings'
           position: 9
-  childNodes:
-    content:
-      type: 'TYPO3.Neos:ContentCollection'
   properties:
     animation:
       type: string

--- a/Configuration/NodeTypes.Navigation.yaml
+++ b/Configuration/NodeTypes.Navigation.yaml
@@ -65,14 +65,12 @@
 'M12.Foundation:SideNav':
   superTypes:
     - 'TYPO3.Neos:Content'
+    - 'TYPO3.Neos:ContentCollection'
   ui:
     label: 'Side Nav'
     icon: 'icon-th-list'
     group: 'navigation'
     inlineEditable: TRUE
-  childNodes:
-    content:
-      type: 'TYPO3.Neos:ContentCollection'
 
 
 #
@@ -98,6 +96,7 @@
 'M12.Foundation:SubNav':
   superTypes:
     - 'TYPO3.Neos:Content'
+    - 'TYPO3.Neos:ContentCollection'
   ui:
     label: 'Sub Nav'
     icon: 'icon-barcode'
@@ -118,9 +117,6 @@
         inspector:
           group: 'options'
           editor: 'TYPO3.Neos/Inspector/Editors/TextFieldEditor'
-  childNodes:
-    content:
-      type: 'TYPO3.Neos:ContentCollection'
 
 
 #

--- a/Configuration/NodeTypes.Structure.yaml
+++ b/Configuration/NodeTypes.Structure.yaml
@@ -6,6 +6,7 @@
 'M12.Foundation:Container':
   superTypes:
     - 'TYPO3.Neos:Content'
+    - 'TYPO3.Neos:ContentCollection'
     - 'M12.Foundation:AbstractDevCustomTag'
     - 'M12.Foundation:AbstractNavSailingType'
     - 'M12.Foundation:AbstractNodeTitle'
@@ -14,12 +15,6 @@
     icon: 'icon-hdd'
     group: 'structure'
     inlineEditable: TRUE
-  constraints:
-    nodeTypes:
-      '*': FALSE # Disallow everything, all content must go into child ContentCollection
-  childNodes:
-    content:
-      type: 'TYPO3.Neos:ContentCollection'
 
 
 
@@ -38,6 +33,7 @@
 'M12.Foundation:Column':
   superTypes:
     - 'TYPO3.Neos:Content'
+    - 'TYPO3.Neos:ContentCollection'
     - 'M12.Foundation:AbstractDevCustomTag'
     - 'M12.Foundation:AbstractNavSailingType'
     - 'M12.Foundation:AbstractNodeTitle'
@@ -50,12 +46,6 @@
         grid:
           label: 'Grid options'
           position: 6
-  constraints:
-    nodeTypes:
-      '*': FALSE # Disallow everything, all content must go into child ContentCollection
-  childNodes:
-    column:
-      type: 'TYPO3.Neos:ContentCollection'
   postprocessors:
     GridColumnPropertiesPostprocesor:
       postprocessor: 'M12\Foundation\NodeTypePostprocessor\GridColumnNodeTypePostprocessor'
@@ -164,6 +154,7 @@
 'M12.Foundation:BlockGrid':
   superTypes:
     - 'TYPO3.Neos:Content'
+    - 'TYPO3.Neos:ContentCollection'
     - 'M12.Foundation:AbstractNavSailingType'
   ui:
     label: 'Block Grid'
@@ -175,12 +166,6 @@
         grid:
           label: 'Block Grid settings'
           position: 9
-  constraints:
-    nodeTypes:
-      '*': FALSE # Disallow everything, all content must go into child ContentCollection
-  childNodes:
-    content:
-      type: 'TYPO3.Neos:ContentCollection'
   postprocessors:
     ColumnPostprocesor:
       postprocessor: 'M12\Foundation\NodeTypePostprocessor\BlockGridNodeTypePostprocessor'

--- a/Resources/Private/TypoScript/Prototypes/Accordion.ts2
+++ b/Resources/Private/TypoScript/Prototypes/Accordion.ts2
@@ -28,7 +28,5 @@ prototype(M12.Foundation:AccordionItem) < prototype(M12.Foundation:Content) {
     	id = ${accordionItemId}
 	}
 
-	accordionItemContent = TYPO3.Neos:ContentCollection {
-		nodePath = 'content'
-	}
+	accordionItemContent = TYPO3.Neos:ContentCollectionRenderer
 }

--- a/Resources/Private/TypoScript/Prototypes/Alert.ts2
+++ b/Resources/Private/TypoScript/Prototypes/Alert.ts2
@@ -2,7 +2,5 @@ prototype(M12.Foundation:Alert) < prototype(M12.Foundation:Content) {
 	attributes.class.base = 'alert-box'
 	attributes.class.appearance = ${q(node).property('classAppearance') ? q(node).property('classAppearance') : null}
 
-	alertContent = TYPO3.Neos:ContentCollection {
-		nodePath = 'content'
-	}
+	alertContent = TYPO3.Neos:ContentCollectionRenderer
 }

--- a/Resources/Private/TypoScript/Prototypes/BlockGrid.ts2
+++ b/Resources/Private/TypoScript/Prototypes/BlockGrid.ts2
@@ -6,9 +6,7 @@ prototype(M12.Foundation:BlockGrid) < prototype(M12.Foundation:Content) {
 	attributes.class.itemsPerRow = ${q(node).property('classGridItemsPerRow') ? String.trim(Array.join(q(node).property('classGridItemsPerRow'), ' ')) : null}
 	@override.parentAttributes = ${this.attributes}
 
-	blockGridContent = TYPO3.Neos:ContentCollection {
-		nodePath = 'content'
-
+	blockGridContent = TYPO3.Neos:ContentCollectionRenderer {
 		iterationName = 'iterator'
 		itemName = 'node'
 		itemRenderer = M12.Foundation:BlockGridItem

--- a/Resources/Private/TypoScript/Prototypes/Container.ts2
+++ b/Resources/Private/TypoScript/Prototypes/Container.ts2
@@ -1,7 +1,5 @@
 prototype(M12.Foundation:Container) < prototype(M12.Foundation:Content) {
 	node = ${node}
 
-	content = TYPO3.Neos:ContentCollection {
-		nodePath = 'content'
-	}
+	content = TYPO3.Neos:ContentCollectionRenderer
 }

--- a/Resources/Private/TypoScript/Prototypes/Dropdown.ts2
+++ b/Resources/Private/TypoScript/Prototypes/Dropdown.ts2
@@ -28,7 +28,5 @@ prototype(M12.Foundation:DropdownContent) < prototype(M12.Foundation:DropdownAbs
 
 	attributes.class.content = ${q(node).property('dropdownPadding') ? 'content' : null}
 
-	content = TYPO3.Neos:ContentCollection {
-		nodePath = 'content'
-	}
+	content = TYPO3.Neos:ContentCollectionRenderer
 }

--- a/Resources/Private/TypoScript/Prototypes/Form.ts2
+++ b/Resources/Private/TypoScript/Prototypes/Form.ts2
@@ -5,9 +5,7 @@ prototype(M12.Foundation:Form) < prototype(M12.Foundation:Content) {
 	actionUri = ${q(node).property('actionUri') ? q(node).property('actionUri') : '#'}
 	methodType = ${q(node).property('methodType') == 'get' ? 'get' : 'post'}
 
-	content = TYPO3.Neos:ContentCollection {
-		nodePath = 'content'
-	}
+	content = TYPO3.Neos:ContentCollectionRenderer
 }
 
 
@@ -42,9 +40,7 @@ prototype(M12.Foundation:FormFieldset) < prototype(M12.Foundation:Content) {
 	templatePath = 'resource://M12.Foundation/Private/Templates/NodeTypes/Form.html'
 	sectionName = 'formFieldset'
 
-	content = TYPO3.Neos:ContentCollection {
-		nodePath = 'content'
-	}
+	content = TYPO3.Neos:ContentCollectionRenderer
 }
 
 

--- a/Resources/Private/TypoScript/Prototypes/Grid.ts2
+++ b/Resources/Private/TypoScript/Prototypes/Grid.ts2
@@ -13,9 +13,7 @@ prototype(M12.Foundation:Column) < prototype(M12.Foundation:Content) {
 	attributes.class.gridResetOrder = ${q(node).property('classGridResetOrder') ? Array.join(q(node).property('classGridResetOrder'), ' ') : null}
 	attributes.class.gridAlign = ${q(node).property('classGridAlign') ? Array.join(q(node).property('classGridAlign'), ' ') : null}
 
-	columnContent = TYPO3.Neos:ContentCollection {
-		nodePath = 'column'
-	}
+	columnContent = TYPO3.Neos:ContentCollectionRenderer
 }
 
 # Basic implementation of a flexible GridColumns element,

--- a/Resources/Private/TypoScript/Prototypes/NavItem.ts2
+++ b/Resources/Private/TypoScript/Prototypes/NavItem.ts2
@@ -6,9 +6,7 @@ prototype(M12.Foundation:NavItem) < prototype(M12.Foundation:Content) {
 	attributes.class.divider = ${q(node).property('classDivider') ? 'divider' : null}
 	attributesHref = ${q(node).property('htmlHref') ? String.trim(q(node).property('htmlHref')) : null}
 
-	navItemContent = TYPO3.Neos:ContentCollection {
-		nodePath = 'content'
-	}
+	navItemContent = TYPO3.Neos:ContentCollectionRenderer
 
 	tag = ${this.isSubNav ? 'dd' : 'li'}
 }

--- a/Resources/Private/TypoScript/Prototypes/Orbit.ts2
+++ b/Resources/Private/TypoScript/Prototypes/Orbit.ts2
@@ -22,9 +22,7 @@ prototype(M12.Foundation:Orbit) < prototype(M12.Foundation:Content) {
 
 	@override.parentAttributes = ${this.attributes}
 
-	orbitContent = TYPO3.Neos:ContentCollection {
-		nodePath = 'content'
-
+	orbitContent = TYPO3.Neos:ContentCollectionRenderer {
 		iterationName = 'iterator'
 		itemName = 'orbitNodeItem'
 		itemRenderer = M12.Foundation:OrbitItem

--- a/Resources/Private/TypoScript/Prototypes/Panel.ts2
+++ b/Resources/Private/TypoScript/Prototypes/Panel.ts2
@@ -2,7 +2,5 @@ prototype(M12.Foundation:Panel) < prototype(M12.Foundation:Content) {
 	attributes.class.base = 'panel'
 	attributes.class.callout = ${q(node).property('classCallout') ? 'callout' : null}
 
-	panelContent = TYPO3.Neos:ContentCollection {
-		nodePath = 'content'
-	}
+	panelContent = TYPO3.Neos:ContentCollectionRenderer
 }

--- a/Resources/Private/TypoScript/Prototypes/RevealModal.ts2
+++ b/Resources/Private/TypoScript/Prototypes/RevealModal.ts2
@@ -2,7 +2,5 @@ prototype(M12.Foundation:RevealModal) < prototype(M12.Foundation:Content) {
 	attributes.class.base = 'reveal-modal'
 	attributes.class.size = ${q(node).property('classRevealSize') ? q(node).property('classRevealSize') : null}
 
-	revealModalContent = TYPO3.Neos:ContentCollection {
-		nodePath = 'content'
-	}
+	revealModalContent = TYPO3.Neos:ContentCollectionRenderer
 }

--- a/Resources/Private/TypoScript/Prototypes/SideNav.ts2
+++ b/Resources/Private/TypoScript/Prototypes/SideNav.ts2
@@ -1,7 +1,5 @@
 prototype(M12.Foundation:SideNav) < prototype(M12.Foundation:Content) {
 	attributes.class.base = 'side-nav'
 
-	sideNavContent = TYPO3.Neos:ContentCollection {
-		nodePath = 'content'
-	}
+	sideNavContent = TYPO3.Neos:ContentCollectionRenderer
 }

--- a/Resources/Private/TypoScript/Prototypes/SubNav.ts2
+++ b/Resources/Private/TypoScript/Prototypes/SubNav.ts2
@@ -3,7 +3,5 @@ prototype(M12.Foundation:SubNav) < prototype(M12.Foundation:Content) {
 
 	subNavTitle = ${q(node).property('title') ? q(node).property('title') : null}
 
-	subNavContent = TYPO3.Neos:ContentCollection {
-		nodePath = 'content'
-	}
+	subNavContent = TYPO3.Neos:ContentCollectionRenderer
 }

--- a/Resources/Private/TypoScript/Prototypes/Tabs.ts2
+++ b/Resources/Private/TypoScript/Prototypes/Tabs.ts2
@@ -59,7 +59,5 @@ prototype(M12.Foundation:TabItem) < prototype(M12.Foundation:Content) {
 	attributes.class.active = ${q(node).property('activeTab') ? 'active' : null}
 	attributes.id = ${q(node).property('customHtmlId') ? q(node).property('customHtmlId') : ('tab-'+q(node).property('_nodeData.identifier'))}
 
-	content = TYPO3.Neos:ContentCollection {
-		nodePath = 'content'
-	}
+	content = TYPO3.Neos:ContentCollectionRenderer
 }


### PR DESCRIPTION
Render child nodes directly with TYPO3.Neos:ContentCollectionRenderer.
This change depends on https://review.typo3.org/#/c/36926/
To review: cherry-pick this change, disable JS minification in Neos, build CSS with grunt (in scripts folder).

Not thoroughly tested yet with all the elements!

Watch out for this problem: https://jira.typo3.org/browse/NEOS-1013
Outline around extended CC is not drown because of this: https://jira.typo3.org/browse/NEOS-545?jql=text%20~%20%22contentcollection%22
It can be solved with smth like this: https://review.typo3.org/#/c/36926/5/Classes/TYPO3/Neos/Service/ContentElementWrappingService.php
But it needs to go in a separate commit.
Once the main commit is merged, I'll sort out a few simple things like the docs and source comments.
