### PR TITLE
[TASK] CI tests update m12/* packages before running the tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,13 +10,13 @@ dependencies:
     - docker info && docker version
 
   override:
-    - docker pull tutum/mariadb:latest
-    - docker pull million12/behat-selenium:latest
-    - docker pull million12/neos-typostrap-distribution:latest
+    - docker pull million12/mariadb
+    - docker pull million12/behat-selenium
+    - docker pull million12/neos-typostrap-distribution
 
   post:
     # Launch DB backend
-    - docker run -d --name=db --env="MARIADB_PASS=my-pass" tutum/mariadb
+    - docker run -d --name=db --env="MARIADB_PASS=my-pass" million12/mariadb
     - docker logs -f db | tee -a ${CIRCLE_ARTIFACTS}/docker-db.log:
         background: true
 
@@ -28,8 +28,26 @@ test:
     # M12.Foundation / M12.FoundationSite packages
     # and do some basics checks.
     # ######################################################
-    - docker run -d --name=neos -p=8080:80 --link=db:db --env="T3APP_NAME=neos" --env="T3APP_VHOST_NAMES=neos dev.neos behat.dev.neos" --env="T3APP_DO_INIT_TESTS=true" --env="T3APP_ALWAYS_DO_PULL=true" million12/neos-typostrap-distribution
-    - docker logs -f neos > ${CIRCLE_ARTIFACTS}/docker-neos.log:
+    - |
+      docker run -d \
+        --name=neos -p=8080:80 \
+        --link=db:db \
+        --env="T3APP_NAME=neos" \
+        --env="T3APP_VHOST_NAMES=neos dev.neos behat.dev.neos" \
+        --env="T3APP_DO_INIT_TESTS=true" \
+        --env="T3APP_ALWAYS_DO_PULL=true" \
+        million12/neos-typostrap-distribution " \
+          su www -c \"
+            cd ~/neos; \
+            composer update m12/*; \
+            cd Packages/Plugins/M12.Foundation; \
+            git fetch && git checkout --force $CIRCLE_BRANCH; \
+            cd ~/neos; \
+            ./flow flow:cache:flush --force; \
+            ./flow cache:warmup
+          \"
+        "
+    - docker logs -f neos > ${CIRCLE_ARTIFACTS}/docker-neos.log 2>&1:
         background: true
     # Wait till TYPO3 Neos is fully configured
     - while true; do if grep "nginx entered RUNNING state" ${CIRCLE_ARTIFACTS}/docker-neos.log; then break; else sleep 1; fi done
@@ -39,7 +57,7 @@ test:
     - curl -s --head http://neos:8080 | grep "HTTP/1.1 200 OK" && curl -s --head http://neos:8080 | grep "X-Flow-Powered"
     - curl -s -L http://neos:8080/neos | grep "TYPO3 Neos Login"
     
-    # Run Neos unit tests.
+    # Run unit tests:
     - |
       docker run -ti --volumes-from=neos --link=neos:web --link=db:db million12/behat-selenium "
         env && \
@@ -50,3 +68,14 @@ test:
           bin/phpunit -c Build/BuildEssentials/PhpUnit/UnitTests.xml --colors
         \"
       "
+    # Run functional tests:
+    - |
+      docker run -ti --volumes-from=neos --link=neos:web --link=db:db million12/behat-selenium "
+        env && \
+        echo \$WEB_PORT_80_TCP_ADDR \$WEB_ENV_T3APP_VHOST_NAMES >> /etc/hosts && cat /etc/hosts && \
+        su www -c \"
+          cd ~/neos && \
+          echo -e '\n\n======== RUNNING FUNCTIONAL TESTS =======\n\n' && \
+          bin/phpunit -c Build/BuildEssentials/PhpUnit/FunctionalTests.xml --colors
+        \"
+      " || true


### PR DESCRIPTION
Image `million12/neos-typostrap-distribution` might have outdated
M12.Foundation version installed. 

With this change, before we run tests inside `million12/neos-typostrap-distribution` (which uses M12.Foundation), we first update the package, then run the test.