### PR TITLE
[BUGFIX] Fix broken multi-select selectors

### DIFF
--- a/Classes/M12/Foundation/NodeTypePostprocessor/AbstractGridNodeTypePostprocessor.php
+++ b/Classes/M12/Foundation/NodeTypePostprocessor/AbstractGridNodeTypePostprocessor.php
@@ -67,8 +67,7 @@ abstract class AbstractGridNodeTypePostprocessor implements NodeTypePostprocesso
 			$propertyName = sprintf('classGrid%s', ucfirst($set));
 
 			$editorValues = [];
-			$defaultValue = isset($setData['defaults']) ? $setData['defaults'] : [''];
-			
+
 			/** @var string $device: small, medium, large */
 			foreach ($this->settings['devices'] as $device => $deviceData) {
 				$groupLabel = $deviceData['label'];
@@ -77,7 +76,6 @@ abstract class AbstractGridNodeTypePostprocessor implements NodeTypePostprocesso
 
 			$configuration['properties'][$propertyName] = [
 				'type' => 'array',
-				'defaultValue' => $defaultValue,
 				'ui' => [
 					'label' => $setData['label'],
 					'reloadIfChanged' => true,
@@ -86,19 +84,17 @@ abstract class AbstractGridNodeTypePostprocessor implements NodeTypePostprocesso
 						'position' => ($k+1)*10,
 						'editor' => 'TYPO3.Neos/Inspector/Editors/SelectBoxEditor',
 						'editorOptions' => [
-							'multiple' => TRUE,
-							'allowEmpty' => TRUE,
-							'placeholder' => 'placeholder text...',
 							'values' => $editorValues,
 						],
 					],
 				],
 			];
-			
+			if (isset($setData['defaults'])) {
+				$configuration['properties'][$propertyName]['defaultValue'] = $setData['defaults'];
+			}
+
 			$k++;
 		}
-		
-//		\TYPO3\Flow\var_dump($configuration);
 	}
 
 	/**

--- a/Configuration/NodeTypes.ButtonsAndLinks.yaml
+++ b/Configuration/NodeTypes.ButtonsAndLinks.yaml
@@ -192,7 +192,6 @@
           group: 'buttonOptions'
     classOptions:
       type: array
-      defaultValue: ['']
       ui:
         label: 'Button options'
         reloadIfChanged: TRUE
@@ -201,7 +200,6 @@
           editor: 'TYPO3.Neos/Inspector/Editors/SelectBoxEditor'
           editorOptions:
             placeholder: 'Button options'
-            allowEmpty: TRUE
             values:
               tiny:
                 label: 'Size: Tiny'

--- a/Configuration/NodeTypes.FontIcon.yaml
+++ b/Configuration/NodeTypes.FontIcon.yaml
@@ -22,7 +22,6 @@
             placeholder: '...as listed on fontawesome.io'
     faOptions:
       type: array
-      defaultValue: ['']
       ui:
         label: 'Icon options'
         reloadIfChanged: TRUE
@@ -31,7 +30,6 @@
           editor: 'TYPO3.Neos/Inspector/Editors/SelectBoxEditor'
           editorOptions:
             placeholder: 'Icon options'
-            allowEmpty: TRUE
             values:
               # Icon size
               fa-lg:


### PR DESCRIPTION
`allowEmpty` option in multi-select causes it to break.
Option `multiple` is redundant for type `array`.
Also `defaultValue` should be set only when required.

Fixes: #34 