### PR TITLE
Use viewhelper to link to root page in TopBar home link. Fixes #44

### DIFF
--- a/Resources/Private/Templates/NodeTypes/TopBar.html
+++ b/Resources/Private/Templates/NodeTypes/TopBar.html
@@ -9,7 +9,7 @@
 		<ul class="title-area">
 			<f:if condition="{topBarTitle}">
 				<li class="name">
-					<h1><a href="/"><span>{topBarTitle -> f:format.raw()}</span></a></h1>
+					<h1><neos:link.node node="~"><span>{topBarTitle -> f:format.raw()}</span></neos:link.node></h1>
 				</li>
 			</f:if>
 


### PR DESCRIPTION
Using viewhelper to link to root page, we can be sure that dimensions aren't ignored and Home link leads to root in current dimension.